### PR TITLE
Update pngpread.c

### DIFF
--- a/src/l4/pkg/libpng/lib/contrib/pngpread.c
+++ b/src/l4/pkg/libpng/lib/contrib/pngpread.c
@@ -220,7 +220,22 @@ png_push_read_chunk(png_structrp png_ptr, png_inforp info_ptr)
       if ((png_ptr->mode & PNG_AFTER_IDAT) != 0)
          png_benign_error(png_ptr, "Too many IDATs found");
    }
-
+   
+   else
+   {
+      png_alloc_size_t limit = PNG_SIZE_MAX;
+# ifdef PNG_SET_USER_LIMITS_SUPPORTED
+      if (png_ptr->user_chunk_malloc_max > 0 &&
+          png_ptr->user_chunk_malloc_max < limit)
+         limit = png_ptr->user_chunk_malloc_max;
+# elif PNG_USER_CHUNK_MALLOC_MAX > 0
+      if (PNG_USER_CHUNK_MALLOC_MAX < limit)
+         limit = PNG_USER_CHUNK_MALLOC_MAX;
+# endif
+      if (png_ptr->push_length > limit)
+         png_chunk_error(png_ptr, "chunk data is too large");
+   }
+      
    if (chunk_name == png_IHDR)
    {
       if (png_ptr->push_length != 13)


### PR DESCRIPTION
This reflects a patch to security flaws present in libpng, as seen in https://github.com/glennrp/libpng/commit/347538efbdc21b8df684ebd92d37400b3ce85d55#.